### PR TITLE
fix: add DSQL-compatible index output

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Supported options:
 | -a, --data-only           | Dump only the data, not the schema (data definitions)                                                      |
 | -s, --schema-only         | Dump only the schema (data definitions), not the data                                                       |
 | -c, --clean               | Output commands to DROP all the dumped database objects prior to outputting the commands for creating them |
+| --dsql-compatible         | Output DSQL-compatible SQL for restore, including `CREATE INDEX ASYNC`                                     |
 | --help                    | Display help for command                                                                                    |
 | --version                 | Display version number                                                                                      |
 

--- a/bun.lock
+++ b/bun.lock
@@ -18,11 +18,11 @@
         "postgres": "^3.4.9",
       },
       "optionalDependencies": {
-        "dsql_dump-darwin-arm64": "1.7.0",
-        "dsql_dump-darwin-x64": "1.7.0",
-        "dsql_dump-linux-arm64-gnu": "1.7.0",
-        "dsql_dump-linux-x64-gnu": "1.7.0",
-        "dsql_dump-windows-x64": "1.7.0",
+        "dsql_dump-darwin-arm64": "1.7.1",
+        "dsql_dump-darwin-x64": "1.7.1",
+        "dsql_dump-linux-arm64-gnu": "1.7.1",
+        "dsql_dump-linux-x64-gnu": "1.7.1",
+        "dsql_dump-windows-x64": "1.7.1",
       },
       "peerDependencies": {
         "typescript": "^6",
@@ -355,16 +355,6 @@
     "dot-prop": ["dot-prop@5.3.0", "", { "dependencies": { "is-obj": "^2.0.0" } }, "sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q=="],
 
     "dotgitignore": ["dotgitignore@2.1.0", "", { "dependencies": { "find-up": "^3.0.0", "minimatch": "^3.0.4" } }, "sha512-sCm11ak2oY6DglEPpCB8TixLjWAxd3kJTs6UIcSasNYxXdFPV+YKlye92c8H4kKFqV5qYMIh7d+cYecEg0dIkA=="],
-
-    "dsql_dump-darwin-arm64": ["dsql_dump-darwin-arm64@1.7.0", "", { "os": "darwin", "cpu": "arm64", "bin": { "dsql_dump": "bin/dsql_dump" } }, "sha512-aJ3nKpFwxk/C7nWjsggNMFL2sDMOgfHBD1F7d3xah87PBCEWADbcf4/YWF69NbImXgYW0fCmYUvvTA5kamJIZA=="],
-
-    "dsql_dump-darwin-x64": ["dsql_dump-darwin-x64@1.7.0", "", { "os": "darwin", "cpu": "x64", "bin": { "dsql_dump": "bin/dsql_dump" } }, "sha512-TPtChc48Al6EP2d3hF/E7ZFN3eSh8W2gjGqtfZ8ZhEI+0CUph8W3JVseEm8JwoNXmTIS0sTmM7/OgmTKz/6p2w=="],
-
-    "dsql_dump-linux-arm64-gnu": ["dsql_dump-linux-arm64-gnu@1.7.0", "", { "os": "linux", "cpu": "arm64", "bin": { "dsql_dump": "bin/dsql_dump" } }, "sha512-9rz0O0Veq+rGGWQCoyuOMjenxNAWMoPX0SAlVDtXUTx7MiRCRB4g/XDL+02NPrs8DfnHyjazmDUHgiRe7QXyNA=="],
-
-    "dsql_dump-linux-x64-gnu": ["dsql_dump-linux-x64-gnu@1.7.0", "", { "os": "linux", "cpu": "x64", "bin": { "dsql_dump": "bin/dsql_dump" } }, "sha512-rRuxJcqOXB8mO85qxsurFc0Cq44/albiDbmoPpdoO/lKu1rsrUL1RT8tZFhF1HsRsMEVyWpQdiC0g2t/z6tIOw=="],
-
-    "dsql_dump-windows-x64": ["dsql_dump-windows-x64@1.7.0", "", { "os": "win32", "cpu": "x64", "bin": { "dsql_dump": "bin/dsql_dump.exe" } }, "sha512-TLGHyt/RkZbEnwbPLnFcvRD68mcjXHn3FXs0rmvO1bldXIc80d1fwigKHm6Kf2lVerww0p/9IH8zmYoNJgWZJQ=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -107,7 +107,7 @@ export default [
       ],
 
       // Import rules
-      'import/no-unresolved': ['error'],
+      'import/no-unresolved': ['error', { ignore: ['^bun:test$'] }],
       'import/order': [
         'warn',
         {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "husky",
+    "test": "bun test",
     "lint": "eslint",
     "typecheck": "bunx tsc --noEmit",
     "build": "./scripts/build.sh",

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -4,6 +4,8 @@ export interface DumpOptions {
   schema: string;
   clean: boolean;
   dataOnly: boolean;
+  schemaOnly: boolean;
+  dsqlCompatible: boolean;
 }
 
 export class OutputFormatter {

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ Options:
   -a, --data-only                  dump only the data, not the schema
   -s, --schema-only                dump only the schema, not the data
   -c, --clean                      output commands to DROP objects before creating them
+      --dsql-compatible            output DSQL-compatible SQL for restore
       --help                       display help for command
       --version                    display version number
 
@@ -60,6 +61,7 @@ async function main() {
       "data-only": { type: "boolean", short: "a" },
       "schema-only": { type: "boolean", short: "s" },
       "clean": { type: "boolean", short: "c" },
+      "dsql-compatible": { type: "boolean" },
     },
     allowPositionals: false,
   })
@@ -93,6 +95,7 @@ async function main() {
       clean: options.clean || false,
       dataOnly: options["data-only"] || false,
       schemaOnly: options["schema-only"] || false,
+      dsqlCompatible: options["dsql-compatible"] || false,
     }
 
     // Output header
@@ -145,7 +148,7 @@ async function main() {
       if (standaloneIndexes.length > 0) {
         console.log(formatter.formatSectionComment("Indexes"))
         for (const index of standaloneIndexes) {
-          const indexDdl = indexExtractor.formatCreateIndex(index, dumpOptions.clean)
+          const indexDdl = indexExtractor.formatCreateIndex(index, dumpOptions.clean, dumpOptions.dsqlCompatible)
           if (indexDdl.trim()) {
             console.log(indexDdl)
           }
@@ -192,7 +195,7 @@ async function main() {
       if (standaloneIndexes.length > 0) {
         console.log(formatter.formatSectionComment("Indexes"))
         for (const index of standaloneIndexes) {
-          const indexDdl = indexExtractor.formatCreateIndex(index, dumpOptions.clean)
+          const indexDdl = indexExtractor.formatCreateIndex(index, dumpOptions.clean, dumpOptions.dsqlCompatible)
           if (indexDdl.trim()) {
             console.log(indexDdl)
           }

--- a/src/schema/indexes.test.ts
+++ b/src/schema/indexes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test"
+import { IndexExtractor, type Index } from "./indexes"
+
+const index: Index = {
+  name: "student_school_email_unique",
+  schema: "public",
+  tableName: "student",
+  owner: "admin",
+  definition: "CREATE UNIQUE INDEX student_school_email_unique ON public.student (school_id, email)",
+  isUnique: true,
+  isPrimaryKey: false,
+  isConstraintIndex: false,
+}
+
+describe("IndexExtractor", () => {
+  test("formats regular index DDL by default", () => {
+    const extractor = new IndexExtractor(null as never)
+
+    expect(extractor.formatCreateIndex(index)).toContain(
+      "CREATE UNIQUE INDEX \"student_school_email_unique\" ON \"public\".\"student\" (\"school_id\", \"email\");",
+    )
+  })
+
+  test("formats DSQL-compatible index DDL", () => {
+    const extractor = new IndexExtractor(null as never)
+
+    expect(extractor.formatCreateIndex(index, false, true)).toContain(
+      "CREATE UNIQUE INDEX ASYNC \"student_school_email_unique\" ON \"public\".\"student\" (\"school_id\", \"email\");",
+    )
+  })
+})

--- a/src/schema/indexes.ts
+++ b/src/schema/indexes.ts
@@ -53,7 +53,7 @@ export class IndexExtractor {
     }))
   }
 
-  formatCreateIndex(index: Index, clean: boolean = false): string {
+  formatCreateIndex(index: Index, clean: boolean = false, dsqlCompatible: boolean = false): string {
     const lines: string[] = []
 
     // Skip indexes that back constraints - they will be created by the constraints
@@ -74,14 +74,14 @@ export class IndexExtractor {
     }
 
     // Reformat the index definition with quoted identifiers
-    const quotedDefinition = this.reformatIndexDefinition(index.definition)
+    const quotedDefinition = this.reformatIndexDefinition(index.definition, dsqlCompatible)
     lines.push(`${quotedDefinition};`)
     lines.push("")
 
     return lines.join("\n")
   }
 
-  private reformatIndexDefinition(definition: string): string {
+  private reformatIndexDefinition(definition: string, dsqlCompatible: boolean): string {
     // Parse the CREATE INDEX statement and quote all identifiers
     // Example: "CREATE INDEX index_name ON schema.table (col1, col2)"
     // Becomes: "CREATE INDEX \"index_name\" ON \"schema\".\"table\" (\"col1\", \"col2\")"
@@ -89,8 +89,12 @@ export class IndexExtractor {
     // Remove DSQL-specific USING clause first
     let cleanDef = definition.replace(/ USING btree_index /, " ")
 
+    if (dsqlCompatible) {
+      cleanDef = cleanDef.replace(/^(CREATE\s+(?:UNIQUE\s+)?INDEX)(\s+)/i, "$1 ASYNC$2")
+    }
+
     // Pattern to match CREATE [UNIQUE] INDEX index_name ON schema.table (columns)
-    const createIndexPattern = /^(CREATE\s+(?:UNIQUE\s+)?INDEX\s+)(\w+)(\s+ON\s+)(\w+)\.(\w+)(\s*\([^(]+\))/i
+    const createIndexPattern = /^(CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:ASYNC\s+)?)(\w+)(\s+ON\s+)(\w+)\.(\w+)(\s*\([^(]+\))/i
     const match = cleanDef.match(createIndexPattern)
 
     if (match && match[2] && match[4] && match[5]) {


### PR DESCRIPTION
## Summary
- add --dsql-compatible flag for restore-friendly DSQL dumps
- emit CREATE INDEX ASYNC for standalone indexes when enabled
- add Bun tests for default and DSQL-compatible index formatting

## Tests
- bun test
- pre-commit hook: eslint src/
- pre-commit hook: bunx tsc --noEmit